### PR TITLE
Implemented: User namespace remapping (OFBIZ-12795)

### DIFF
--- a/demo-backup/ofbizdocker/README.md
+++ b/demo-backup/ofbizdocker/README.md
@@ -14,8 +14,8 @@ demo sites in the future.
 Files in this subdirectory of the ofbiz-tools repository reflect files which should be created on the root filesystem of ofbiz-vm1.apache.org with the following additions and/or settings:
 * /etc/cron.d/ofbizdocker
   * Owned by root with permissions 0644
-* /home/ofbizdocker/pull-rebuild-restart.sh
-  * Owned by ofbizdocker user with permissions 0775
+* /home/ofbizdocker/pull-and-restart.sh
+  * Owned by ofbizdocker user with permissions 0755
 * /home/ofbizdocker/ofbiz-framework
   * Git clone of https://github.com/apache/ofbiz-framework with the experimental-docker branch checked otu.
 
@@ -34,3 +34,10 @@ The `pull-and-restart.sh` script does the following:
 The `demo-trunk` application listens on AJP port 8009.
 
 If in use, the `exp1` application listens on AJP port 38009, the `exp2` application listens on AJP port 48009, and the `exp3` application listens on AJP port 58009. The Apache server on ofbiz-vm1.apache.org has been configured to reverse-proxy to these applications for hostnames exp1.ofbiz.apache.org, exp2.ofbiz.apache.org and exp3.ofbiz.apache.org respectively.
+
+
+## Default user namespace remapping
+
+The docker daemon on ofbiz-vm1.apache.org has been configured to use default user namespace remapping. This means that the UIDs of processes running within containers are mapped to a range of 'high' non-existing UIDs on the host system. Since the UIDs are non-existant, processes with those UIDs will have no priviledges on the host system.
+
+See the `dockremap` entry in file /etc/subuid to see the range of UIDs that will be used for remapping.

--- a/demo-backup/ofbizdocker/home/ofbizdocker/pull-and-restart.sh
+++ b/demo-backup/ofbizdocker/home/ofbizdocker/pull-and-restart.sh
@@ -6,7 +6,7 @@ set -e
 
 cd /home/ofbizdocker
 
-for appDir in exp1 exp2 exp3; do
+for appDir in demo-trunk exp1 exp2 exp3; do
     echo "Restarting $appDir docker-compose application with latest container images."
     pushd "$appDir"
     docker compose pull


### PR DESCRIPTION
Updated README to refer to the use of user namespace remapping by the docker daemon.

Configuration changes to enable user namespace remapping are reflected in the INFRA puppet configuration for the ofbiz-vm1 host.