### PR TITLE
Restored the RAT configuration exclusion rule for jQuery files in the common theme

### DIFF
--- a/rat-excludes.txt
+++ b/rat-excludes.txt
@@ -69,6 +69,7 @@ buildSrc/build/**
 **/plugins/solr/webapp/solr/js/**
 **/plugins/webpos/webapp/webpos/images/**
 **/themes/common-theme/webapp/common-theme/js/*.json
+**/themes/common-theme/webapp/common-theme/js/jquery/**
 **/themes/common-theme/webapp/common-theme/js/i18n/datepicker/**
 **/themes/common-theme/webapp/common-theme/js/plugins/**
 **/themes/common-theme/webapp/images/**


### PR DESCRIPTION
This rule was removed in commit 1e3feec6b60aef6a26bd0ba3d554cd74bda096e5, but it is still required because rat-excludes.txt is also used for the release24.09 branch, where these files are still present.